### PR TITLE
Enable TypeScript option by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = (babel, userOptions) => {
       browsers: env === 'test' ? undefined : ['IE 11', 'Firefox ESR', 'last 2 Chrome versions'],
       node: env === 'test' || '10.0.0',
     },
-    typescript: false,
+    typescript: true,
     useBuiltIns: true,
   }
   const {


### PR DESCRIPTION
IMO this makes sense if we plan to use TS for new projects going forward, and it's safe to enable even if you're only transpiling JS code, since the preset is only responsible for stripping types (which don't exist).